### PR TITLE
clearing match_triple_dict after each sentence

### DIFF
--- a/smatch/smatch.py
+++ b/smatch/smatch.py
@@ -790,6 +790,7 @@ def get_amr_match(cur_amr1, cur_amr2, sent_num=1, justinstance=False, justattrib
     else:
         test_triple_num = len(instance1) + len(attributes1) + len(relation1)
         gold_triple_num = len(instance2) + len(attributes2) + len(relation2)
+    match_triple_dict.clear()
     return best_match_num, test_triple_num, gold_triple_num
 
 


### PR DESCRIPTION
I've been fiddling with issue #23 regarding F1s over 1.0, and the case reported doesn't seem to be the same as the existing issue noted in prior threads (duplicates in the AMR), but is instead because we are directly accessing get_amr_match, inside of using the score_amr_pairs function that normally calls it. A particular necessary reset (calling clear on match_triple_dict) was being called in score_amr_pairs, and therefore not being called.   This meant that the SMATCH is "stateful" in weird ways (the saved, pre-computed node mappings and scores from the last AMR were being assumed for each new one). 

I think this should be solved without issues by clearing the match_triple_dict at the end of get_amr_match function, and this seems to solve the issue.  Any objections?