### PR TITLE
Fix installation readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,10 +168,10 @@ other in the above order.
 Installation
 ------------
 
-You can install `mtool` via `pip` with a command like the following:
+You can install `mtool` via `pip` with the following command:
 
 ```
-pip install git+https://github.com/cfmrp/mtool.git
+pip install git+https://github.com/cfmrp/mtool.git#egg=mtool
 ```
 
 Contributors

--- a/README.md
+++ b/README.md
@@ -177,4 +177,4 @@ pip install git+https://github.com/cfmrp/mtool.git#egg=mtool
 Contributors
 ------------
 
-+ Yuta Korreda <yuta.koreeda.pb@hitachi.com> (@koreyou)
++ Yuta Koreeda <koreyou@mac.com> (@koreyou)


### PR DESCRIPTION
Hi again. Do you mind merging two minor fixes on readme?

1. I added `#egg=mtool` to README for pip install, because I noticed that pip install may fail without `egg` option in some environment (maybe older setuptool?)

2. Changed my email (btw thanks for adding me to the list of contributors). I use koreyou@mac.com in github.