### PR TITLE
Fix ‘’ to '' to avoid encoding problems in reporting

### DIFF
--- a/main.py
+++ b/main.py
@@ -178,7 +178,7 @@ def main():
     normalize = normalizations;
 
   if arguments.alignment is not None and arguments.overlay is None:
-    print("main.py(): option ‘--alignment’ requires ‘--overlay’; exit.",
+    print("main.py(): option '--alignment' requires '--overlay'; exit.",
           file = sys.stderr);
     sys.exit(1);
     

--- a/validate/core.py
+++ b/validate/core.py
@@ -5,25 +5,26 @@ import validate.eds;
 import validate.sdp;
 import validate.ucca;
 from validate.utilities import report;
-
+
+
 def test(graph, actions, stream = sys.stderr):
   n = 0;
   if not isinstance(graph.id, str) or len(graph.id) == 0:
     n += 1;
     report(graph,
-           "missing or invalid ‘id’ property",
+           "missing or invalid 'id' property",
            stream = stream);
   if not isinstance(graph.flavor, int) or graph.flavor not in {0, 1, 2}:
     n += 1;
     report(graph,
-           "missing or invalid ‘flavor’ property",
+           "missing or invalid 'flavor' property",
            stream = stream);
   if not isinstance(graph.framework, str) or \
      graph.framework not in {"ccd", "dm", "pas", "psd", "ud",
                              "eds", "ucca", "amr"}:
     n += 1;
     report(graph,
-           "missing or invalid ‘framework’ property",
+           "missing or invalid 'framework' property",
            stream = stream);
   elif graph.flavor == 0 and \
        graph.framework not in {"ccd", "dm", "pas", "psd", "ud"} or \
@@ -38,7 +39,7 @@ def test(graph, actions, stream = sys.stderr):
     if not isinstance(graph.input, str) or len(graph.input) == 0:
       n += 1;
       report(graph,
-             "missing or invalid ‘input’ property",
+             "missing or invalid 'input' property",
              stream = stream);
 
   if "edges" in actions:

--- a/validate/eds.py
+++ b/validate/eds.py
@@ -1,7 +1,7 @@
 import sys;
 
-from graph import Graph;
 from validate.utilities import report;
+
 
 def test(graph, actions, stream = sys.stderr):
   n = 0;
@@ -16,7 +16,7 @@ def test(graph, actions, stream = sys.stderr):
       message = "missing or invalid anchoring";
     elif len(node.anchors) != 1 \
       or ("from" not in node.anchors[0] or "to" not in node.anchors[0]):
-      message = "invalid ‘anchors’ value: {}".format(node.anchors);
+      message = "invalid 'anchors' value: {}".format(node.anchors);
     if message is not None:
       n += 1;
       report(graph, message,

--- a/validate/utilities.py
+++ b/validate/utilities.py
@@ -10,5 +10,5 @@ def report(graph, message, node = None, edge = None, stream = sys.stderr):
                                        edge.lab if edge.lab else "");
   else:
     edge = "";
-  print("validate(): graph ‘{}’{}{}: {}"
+  print("validate(): graph '{}'{}{}: {}"
         "".format(graph.id, node, edge, message), file = stream);


### PR DESCRIPTION
They show as â€˜â€™ in HTML.