### PR TITLE
Do not crash when there are no nodes.

### DIFF
--- a/score/mces.py
+++ b/score/mces.py
@@ -334,19 +334,20 @@ def evaluate(gold, system, format="json", limit=500000, trace=0):
                       file = sys.stderr);
                 pairs = mapping;
         n_matched = 0
-        best_cv, best_ce = None, None
-        for i, (cv, ce) in enumerate(correspondences(
-                g, s, pairs, rewards, limit, trace,
-                dominated1=g_dominated, dominated2=s_dominated)):
-            assert is_valid(ce)
-            assert is_injective(ce)
-            n = sum(map(len, ce.values()))
-            if n > n_matched:
-                if trace > 1:
-                    print("\n[{}] solution #{}; matches: {}"
-                          "".format(counter, i, n), file = sys.stderr);
-                n_matched = n
-                best_cv, best_ce = cv, ce
+        best_cv, best_ce = {}, {}
+        if g.nodes:
+            for i, (cv, ce) in enumerate(correspondences(
+                    g, s, pairs, rewards, limit, trace,
+                    dominated1=g_dominated, dominated2=s_dominated)):
+                assert is_valid(ce)
+                assert is_injective(ce)
+                n = sum(map(len, ce.values()))
+                if n > n_matched:
+                    if trace > 1:
+                        print("\n[{}] solution #{}; matches: {}"
+                              "".format(counter, i, n), file = sys.stderr);
+                    n_matched = n
+                    best_cv, best_ce = cv, ce
         total_matches += n_matched;
         total_steps += counter;
         tops, labels, properties, anchors, edges, attributes \


### PR DESCRIPTION
Currently the mces score crashes when there are no nodes.
However, `dm` contains the following graph:
```
{"id": "21778143", "flavor": 0, "framework": "dm", "version": 0.9,
  "time": "2019-04-10 (20:16)", "input": "It is.", "nodes": [], "edges": []}
```

The proposed change avoids calling `correspondences` (which unconditionally indexes `pairs`) when there are no nodes in the gold graph, and sets `best_cv` to be an empty dictionary instead of None.