### PR TITLE
Another fix for evaluation of empty graphs.

### DIFF
--- a/score/mces.py
+++ b/score/mces.py
@@ -354,7 +354,7 @@ def evaluate(gold, system, format = "json",
                       file = sys.stderr);
             if set(pairs) != set(mapping): pairs = mapping;
         n_matched = 0
-        best_cv, best_ce = {}, {}
+        best_cv, best_ce = None, None
         if g.nodes and mces_limit > 0:
             for i, (cv, ce) in enumerate(correspondences(
                     g, s, pairs, rewards, mces_limit, trace,
@@ -371,7 +371,7 @@ def evaluate(gold, system, format = "json",
         total_matches += n_matched;
         total_steps += counter;
         tops, labels, properties, anchors, edges, attributes \
-            = g.score(s, best_cv or pairs);
+            = g.score(s, best_cv or pairs or {});
 #        assert n_matched >= n_smatched;
         if trace:
             if n_smatched and n_matched != n_smatched:


### PR DESCRIPTION
The recent changes in mces_limit again broke evaluation of empty graphs.

This time the fix sets best_cv and best_ce back to None, and explicitly uses `best_cv or pairs or {}` as the argument to `g.score`. Another possibility would be to fix `g.score` not to fail when `pairs=[]`, but I am too lazy for that.

Also note that all four combinations ({empty,nonempty} vs {empty,nonempty} graphs) work, it is not necessary to check nodes of the system graph for emptiness.