### PR TITLE
Accept --targets option instead of relying on --source

### DIFF
--- a/main.py
+++ b/main.py
@@ -150,6 +150,7 @@ def main():
                       type = argparse.FileType("r", encoding = ENCODING));
   parser.add_argument("--prefix");
   parser.add_argument("--source");
+  parser.add_argument("--targets", nargs="+");
   parser.add_argument("--pretty", action = "store_true");
   parser.add_argument("--inject");
   parser.add_argument("--version", type = float, default = 1.1);
@@ -397,7 +398,9 @@ def main():
     if arguments.write in {"mrp", "evaluation"}:
       if arguments.write == "evaluation":
         graph.flavor = graph.framework = graph.nodes = graph.edges = None;
-        if graph.source() in {"lpps"}:
+        if arguments.targets:
+          graph.targets(arguments.targets)
+        elif graph.source() in {"lpps"}:
           graph.targets(["dm", "psd", "eds", "ucca", "amr"]);
         elif graph.source() in {"brown", "wsj"}:
           graph.targets(["dm", "psd", "eds"]);


### PR DESCRIPTION
Instead of hard-coding the source-to-target mapping, it can be supplied with a command line argument.