### PR TITLE
Read ud fix

### DIFF
--- a/codec/conllu.py
+++ b/codec/conllu.py
@@ -23,12 +23,13 @@ def read_tuples(stream):
         id = match.group(1);
         continue;
     elif len(line) == 0:
-      # @kleinay: if there is no `text` comment in the conll, one should reconstruct
+      # if there is no `text` comment in the conll, one should reconstruct
       # the input sentence from the FORM column, since it is required in :construct_graph
-      if input is None: ####
-        input = ' '.join(t[1] for t in tuples) ####
-      yield id, input, tuples; ####
-      id, input = None, None; ####
+      if input is None:
+        input = ' '.join(t[1] for t in tuples)
+      yield id, input, tuples;
+      id, input = None, None;
+      tuples = []
     else:
       tuples.append(line.split("\t"));
 

--- a/codec/conllu.py
+++ b/codec/conllu.py
@@ -27,9 +27,10 @@ def read_tuples(stream):
       # the input sentence from the FORM column, since it is required in :construct_graph
       if input is None:
         input = ' '.join(t[1] for t in tuples)
-      yield id, input, tuples;
-      id, input = None, None;
-      tuples = []
+      if tuples:
+        yield id, input, tuples;
+        id, input = None, None;
+        tuples = []
     else:
       tuples.append(line.split("\t"));
 
@@ -134,5 +135,4 @@ def read(stream, framework = None, text = None, anchors = None, trace = 0):
     if trace:
       print("conllu.read(): processing graph #{} ...".format(id),
             file = sys.stderr);
-    if tuples:
-      yield construct_graph(id, input, tuples, framework, text, anchors), None;
+    yield construct_graph(id, input, tuples, framework, text, anchors), None;

--- a/codec/conllu.py
+++ b/codec/conllu.py
@@ -42,7 +42,8 @@ def reconstruct_input_from_tuples(tuples):
   for t in tuples:
     tok = t[1] # FORM column
     sent_str += tok
-    if "SpaceAfter=No" not in t[-1]: # Misc. column (last column)
+    if "SpaceAfter=No" not in t[-1] and t is not tuples[-1]: # Misc. column (last column)
+      # in last token, don't add space in any case
       sent_str += ' '
 
   return sent_str

--- a/codec/conllu.py
+++ b/codec/conllu.py
@@ -26,7 +26,7 @@ def read_tuples(stream):
       # if there is no `text` comment in the conll, one should reconstruct
       # the input sentence from the FORM column, since it is required in :construct_graph
       if input is None:
-        input = ' '.join(t[1] for t in tuples)
+        input = reconstruct_input_from_tuples(tuples)
       if tuples:
         yield id, input, tuples;
         id, input = None, None;
@@ -34,6 +34,19 @@ def read_tuples(stream):
     else:
       tuples.append(line.split("\t"));
 
+def reconstruct_input_from_tuples(tuples):
+  """ Reconstruct input sentence from the CoNLL-U representation.
+  each tuple in tuples correspond to a line in a block. """
+  if not tuples: return ''
+  sent_str = ''
+  for t in tuples:
+    tok = t[1] # FORM column
+    sent_str += tok
+    if "SpaceAfter=No" not in t[-1]: # Misc. column (last column)
+      sent_str += ' '
+
+  return sent_str
+
 def read_anchors(stream):
   if stream is None:
     while True: yield None, None;


### PR DESCRIPTION
Fixing `--read ud` format to handle conllu files that have no "text" comments declaring the input sentence.
The solution is to reconstruct the input sentence from the FORM (#1) column of the segment.